### PR TITLE
Handle "would clobber existing tag" during --refresh

### DIFF
--- a/freepbx_git.php
+++ b/freepbx_git.php
@@ -48,6 +48,7 @@ $help = array(
 	array('--setup', 'Setup new freepbx dev tools environment (use --force to re-setup environment)'),
 	array('--clean', 'Prunes all tags and branches that do no exist on the remote, can be used with the -m command for individual'),
 	array('--refresh', 'Updates all local modules with their remote changes (!!you will lose all untracked branches!!)'),
+	array('--force', 'With --refresh, force-update local tags on conflict without prompting (also used by --setup)'),
 	array('--refreshhard', 'Updates all local modules with their remote changes (!!you will lose all untracked branches and work!!)'),
 	array('--addmergedriver', 'Updates/Adds Relevant Merge Drivers'),
 	array('--switch=<branch>', 'Switch all local modules to branch'),
@@ -233,15 +234,22 @@ if(!isset($options['setup']) && isset($options['switch']) && !empty($options['sw
 }
 
 if(isset($options['refresh'])) {
+	// --force (or -y) forces tag updates without prompting. Otherwise ask once
+	// upfront whether to force automatically or be asked on each conflict.
+	$force = isset($options['force']) || isset($options['y']);
+	if(!$force) {
+		$answer = freepbx::getInput("On tag conflicts, force tag updates automatically? (y = always force / n = ask for each repo)", 'n');
+		$force = (strtolower(trim($answer)) == 'y');
+	}
 	foreach(glob($directory."/*", GLOB_ONLYDIR) as $dir) {
-		freepbx::refreshRepo($dir);
+		freepbx::refreshRepo($dir,'origin',null,false,$force);
 	}
 	exit(0);
 }
 
 if(isset($options['refreshhard'])) {
 	foreach(glob($directory."/*", GLOB_ONLYDIR) as $dir) {
-		freepbx::refreshRepo($dir,'origin',null,true);
+		freepbx::refreshRepo($dir,'origin',null,true,true);
 	}
 	exit(0);
 }

--- a/libraries/Git.php
+++ b/libraries/Git.php
@@ -723,9 +723,9 @@ class GitRepo {
 	 * @access  public
 	 * @return  string
 	 */
-	public function fetch() {
+	public function fetch($force = false) {
 		$this->run("fetch -q");
-		$this->run("fetch --tags -q");
+		$this->run("fetch --tags -q" . ($force ? " --force" : ""));
 		return true;
 	}
 

--- a/libraries/freepbx.php
+++ b/libraries/freepbx.php
@@ -50,8 +50,26 @@ class freepbx {
 		$repo->clean(true,true);
 		freepbx::out("Done");
 		freepbx::outn("\tFetching Changes...");
-		$repo->fetch();
-		freepbx::out("Done");
+		try {
+			$repo->fetch();
+			freepbx::out("Done");
+		} catch (Exception $e) {
+			// A plain "fetch --tags" aborts with "would clobber existing tag"
+			// when a remote tag has been moved/recreated. Force only if told to,
+			// otherwise ask before forcing.
+			freepbx::out("Failed");
+			if(!$force) {
+				$answer = freepbx::getInput("\tFetch failed (a remote tag may have been moved). Force update of local tags? (y/n)", 'n');
+				$force = (strtolower(trim($answer)) == 'y');
+			}
+			if($force) {
+				freepbx::outn("\tForcing tag update...");
+				$repo->fetch(true);
+				freepbx::out("Done");
+			} else {
+				freepbx::out("\tError: unable to fetch, local tags conflict with the remote. Skipping forced update.");
+			}
+		}
 		freepbx::outn("\tChecking out ".$branch." ...");
 		try {
 			$repo->checkout($branch);
@@ -87,9 +105,11 @@ class freepbx {
 	 * @param   string $directory Location of repo
 	 * @param   string $remote The name of the remote origin
 	 * @param	string $final_branch The final branch to checkout after updating (null means whatever it was on before)
+	 * @param	bool $hard True to reset --hard instead of stashing local changes
+	 * @param	bool $force True to force-update local tags on conflict without prompting
 	 * @return  bool
 	 */
-	public static function refreshRepo($directory, $remote = 'origin', $final_branch = null, $hard = false) {
+	public static function refreshRepo($directory, $remote = 'origin', $final_branch = null, $hard = false, $force = false) {
 		$rawname = basename($directory);
 		if($rawname === 'framework') {
 			freepbx::out("Refusing to refresh framework as it will break everything. Do it manually");


### PR DESCRIPTION
## Problem

Running `./freepbx_git.php --refresh` aborted on any repo whose remote had a moved or recreated tag. `git fetch --tags` fails in that case with `would clobber existing tag` and returns a non-zero status, which bubbled up as an **uncaught, empty exception**:

```php
PHP Fatal error:  Uncaught Exception in /usr/src/devtools/libraries/Git.php:262
Stack trace:
#0 Git.php(277): GitRepo->run_command()
#1 Git.php(728): GitRepo->run()
#2 freepbx.php(139): GitRepo->fetch()
#3 freepbx_git.php(237): freepbx::refreshRepo()
```


The message was empty because the `-q` flag suppressed the stderr that would have explained the failure, and a single bad repo aborted the entire refresh run.

## Changes

- **`Git::fetch($force = false)`** — optional flag that adds `--force` to the tag fetch. The library stays non-interactive.
- **`freepbx::refreshRepo(..., $force = false)`** — wraps the fetch in a try/catch. On failure it forces the tag update when `$force` is set, otherwise prompts for that repo. Declining now reports a clear error and continues with the next module instead of crashing the whole run.
- **`freepbx_git.php --refresh`** — resolves the force mode from `--force` (or `-y`), or asks once upfront whether to force automatically or be prompted on each conflict. `--refreshhard` forces tags automatically.
- Documented the `--force` flag in the help output.

## Behavior

| Command | On tag conflict |
|---|---|
| `--refresh` | Asks once upfront: force always, or prompt per repo |
| `--refresh --force` | Forces tag updates, no prompts |
| `--refresh -y` | Same as `--force` |
| `--refreshhard` | Forces tag updates automatically |
